### PR TITLE
Payment: add resource methods to fusebill payment endpoint

### DIFF
--- a/lib/fusebill.js
+++ b/lib/fusebill.js
@@ -37,6 +37,7 @@ var resources = {
   Plans: require('./resources/Plans'),
   PlanProducts: require('./resources/PlanProducts'),
   PaymentMethods: require('./resources/PaymentMethods'),
+  Payments: require('./resources/Payments'),
   Products: require('./resources/Products'),
   Purchases: require('./resources/Purchases'),
   ReverseCharges: require('./resources/ReverseCharges'),

--- a/lib/resources/Payments.js
+++ b/lib/resources/Payments.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var FusebillResource = require('../FusebillResource');
+
+module.exports = FusebillResource.extend({
+
+  path: 'payments',
+  includeBasic: ['list','retrieve', 'update', 'create'],
+});


### PR DESCRIPTION
I noticed that the endpoint for payments was missing from the list. 
